### PR TITLE
Update to stop `curl_multi_select` from timing out

### DIFF
--- a/lib/AhrefsAPI.php
+++ b/lib/AhrefsAPI.php
@@ -348,7 +348,6 @@ class AhrefsAPI {
         if (!$multi)
             $links[0] = $this->paramsURL;
 
-        $mh = curl_multi_init();
         foreach ($links as $key => $params) {
             $ch[$key] = curl_init();
             //setting the links
@@ -358,7 +357,12 @@ class AhrefsAPI {
             curl_setopt($ch[$key], CURLOPT_RETURNTRANSFER, 1);
             curl_setopt($ch[$key], CURLOPT_CONNECTTIMEOUT, 20);
             curl_setopt($ch[$key], CURLOPT_TIMEOUT, 240); //timeout in seconds
-            curl_multi_add_handle($mh,$ch[$key]);
+        }
+
+        $mh = curl_multi_init();
+
+        foreach ($ch as $handle) {
+            curl_multi_add_handle($mh, $handle);
         }
 
         $active = null;
@@ -367,11 +371,13 @@ class AhrefsAPI {
         } while ($mrc == CURLM_CALL_MULTI_PERFORM);
 
         while ($active && $mrc == CURLM_OK) {
-            if (curl_multi_select($mh) != -1) {
-                do {
-                    $mrc = curl_multi_exec($mh, $active);
-                } while ($mrc == CURLM_CALL_MULTI_PERFORM);
+            if (curl_multi_select($mh) == -1) {
+                usleep(1);
             }
+
+            do {
+                $mrc = curl_multi_exec($mh, $active);
+            } while ($mrc == CURLM_CALL_MULTI_PERFORM);
         }
 
         $this->curlInfo = array();


### PR DESCRIPTION
* Moved the call to `curl_multi_init()` to after `curl_init()` calls
* Sleep if `curl_multi_select` returns -1 rather than run if it does not

At this point, it works on my system, as per #2 