### PR TITLE
Wrong Parameter in broken_links

### DIFF
--- a/lib/ArrayRules.php
+++ b/lib/ArrayRules.php
@@ -247,7 +247,7 @@ abstract class ArrayRules
             'url_from' => array('string', true, true),
             'url_to' => array('string', true, true),
             'ahrefs_rank' => array('int', true, true),
-            'domain_rating' => array('int', false, true),
+            'domain_to_rating' => array('int', false, true),
             'ip_from' => array('string', true, true),
             'links_internal' => array('int', true, true),
             'links_external' => array('int', true, true),


### PR DESCRIPTION
Wrong: domain_rating
Right: domain_to_rating

### Testing:
Works:
`https://apiv2.ahrefs.com/?token=xxxxxx&target=de.wikipedia.org&limit=1000&output=json&from=broken_links&mode=subdomains&having=domain_to_rating%3E12`
Fails:
`https://apiv2.ahrefs.com/?token=xxxxxx&target=de.wikipedia.org&limit=1000&output=json&from=broken_links&mode=subdomains&having=domain_rating%3E12`

