### PR TITLE
Allow to use Guzzle HTTP Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
   "require": {
     "ext-curl": "*"
   },
+  "suggest": {
+    "guzzlehttp/guzzle": "Required to use Guzzle HTTP Client mode, require version 6.3+"
+  },
   "autoload": {
     "psr-4": {
       "ahrefs\\AhrefsApiPhp\\": "lib"

--- a/index.php
+++ b/index.php
@@ -13,6 +13,13 @@ use ahrefs\AhrefsApiPhp\AhrefsAPI;
 	 * @param Boolean $debug Debug message
 	 */
 	$Ahrefs = new AhrefsAPI('[YOURTOKEN]', $debug = true);
+	if (class_exists('\\GuzzleHttp\\Client')) {
+		/**
+		 * Use Guzzle HTTP Client mode.
+		 * @param Boolean $use True - use Guzzle, false - use cURL
+		 */
+		$Ahrefs->useGuzzle(true);
+	}
 	/**
 	 * Specify the aim of the request. The mode defines how the target will be interpreted. Example:
 	 * set_target('ahrefs.com/api/')


### PR DESCRIPTION
The cURL extension is sometimes not available or is limited and can not access apiv2.ahrefs.com as well.
We can use the Guzzle HTTP Client (guzzlehttp/guzzle) instead of cURL.
This PR used cURL as the default request handler, but provided the ability to use Guzzle (if available) via a few lines of code.
```
if (class_exists('\\GuzzleHttp\\Client')) {
    $Ahrefs->useGuzzle(true);
}
```
Install Guzzle with Composer, required version are 6.3+
`composer require guzzlehttp/guzzle "~6.3|~7"`